### PR TITLE
Add checks when burning and minting gsol.

### DIFF
--- a/programs/sunrise_beam/src/instructions/burn_gsol.rs
+++ b/programs/sunrise_beam/src/instructions/burn_gsol.rs
@@ -1,42 +1,12 @@
-use crate::{state::ControllerState, token, utils::get_cpi_program_id, BeamProgramError};
+use crate::{token, utils::get_cpi_program_id, BeamProgramError, BurnGsol};
 use anchor_lang::prelude::*;
-use anchor_lang::solana_program::sysvar::{
-    instructions::Instructions as SysvarInstructions, SysvarId,
-};
-use anchor_spl::token::{Mint, Token, TokenAccount};
-
-#[derive(Accounts)]
-pub struct BurnGsol<'info> {
-    #[account(
-        mut,
-        has_one = gsol_mint,
-    )]
-    pub state: Box<Account<'info, ControllerState>>,
-    pub beam: Signer<'info>,
-    #[account(mut)]
-    pub gsol_mint: Box<Account<'info, Mint>>,
-    pub mint_gsol_to_owner: Signer<'info>,
-    #[account(
-        mut,
-        token::mint = gsol_mint,
-        token::authority = mint_gsol_to_owner
-    )]
-    pub mint_gsol_to: Box<Account<'info, TokenAccount>>,
-    pub token_program: Program<'info, Token>,
-    /// CHECK: We check that the address is that of the instructions sysvar.
-    #[account(constraint = SysvarInstructions::check_id(sysvar.key))]
-    pub sysvar: UncheckedAccount<'info>,
-}
 
 pub fn handler(ctx: Context<BurnGsol>, amount: u64) -> Result<()> {
     let accounts = &ctx.accounts;
+    let state_account = &accounts.state;
 
     let cpi_program = get_cpi_program_id(&accounts.sysvar.to_account_info())?;
-    crate::check_beam_parameters(
-        &accounts.state,
-        &accounts.beam.to_account_info(),
-        &cpi_program,
-    )?;
+    state_account.check_beam_validity(&accounts.beam, &cpi_program)?;
 
     let can_burn = { true };
 

--- a/programs/sunrise_beam/src/instructions/burn_gsol.rs
+++ b/programs/sunrise_beam/src/instructions/burn_gsol.rs
@@ -1,41 +1,28 @@
+use crate::{system, token, utils, BeamError, BurnGsol};
 use anchor_lang::prelude::*;
-
-use crate::system::check_beam_validity;
-use crate::utils::get_cpi_program_id;
-use crate::{token, BeamError, BurnGsol};
 
 pub fn handler(ctx: Context<BurnGsol>, amount: u64) -> Result<()> {
     let state = &mut ctx.accounts.state;
 
-    let cpi_program = get_cpi_program_id(&ctx.accounts.sysvar.to_account_info())?;
-    check_beam_validity(state, &ctx.accounts.beam, &cpi_program)?;
+    let cpi_program = utils::get_cpi_program_id(&ctx.accounts.sysvar.to_account_info())?;
+    system::check_beam_validity(state, &ctx.accounts.beam, &cpi_program)?;
 
-    let can_burn = {
-        let details = state.get_mut_beam_details(&ctx.accounts.beam.key());
-        if details.is_none() {
-            return Err(BeamError::UnidentifiedBeam.into());
-        }
-        let details = details.unwrap();
+    let details = state
+        .get_mut_beam_details(&ctx.accounts.beam.key())
+        .ok_or(BeamError::UnidentifiedBeam)?;
 
-        if details.minted > amount {
-            details.minted = details.minted.checked_sub(amount).unwrap();
-            true
-        } else {
-            false
-        }
-    };
-
-    if can_burn {
-        token::burn(
-            amount,
-            &ctx.accounts.gsol_mint.to_account_info(),
-            &ctx.accounts.mint_gsol_to_owner.to_account_info(),
-            &ctx.accounts.mint_gsol_to.to_account_info(),
-            &ctx.accounts.token_program,
-        )?;
-    } else {
+    if details.minted < amount {
         return Err(BeamError::BurnWindowExceeded.into());
     }
+
+    details.minted = details.minted.checked_sub(amount).unwrap();
+    token::burn(
+        amount,
+        &ctx.accounts.gsol_mint.to_account_info(),
+        &ctx.accounts.mint_gsol_to_owner.to_account_info(),
+        &ctx.accounts.mint_gsol_to.to_account_info(),
+        &ctx.accounts.token_program,
+    )?;
 
     Ok(())
 }

--- a/programs/sunrise_beam/src/instructions/burn_gsol.rs
+++ b/programs/sunrise_beam/src/instructions/burn_gsol.rs
@@ -4,6 +4,7 @@ use anchor_lang::prelude::*;
 pub fn handler(ctx: Context<BurnGsol>, amount: u64) -> Result<()> {
     let state = &mut ctx.accounts.state;
 
+    // Check that the requesting program is valid.
     let cpi_program = utils::get_cpi_program_id(&ctx.accounts.sysvar.to_account_info())?;
     system::check_beam_validity(state, &ctx.accounts.beam, &cpi_program)?;
 

--- a/programs/sunrise_beam/src/instructions/burn_gsol.rs
+++ b/programs/sunrise_beam/src/instructions/burn_gsol.rs
@@ -1,4 +1,4 @@
-use crate::{token, utils::get_cpi_program_id, BeamProgramError, BurnGsol};
+use crate::{token, utils::get_cpi_program_id, BeamError, BurnGsol};
 use anchor_lang::prelude::*;
 
 pub fn handler(ctx: Context<BurnGsol>, amount: u64) -> Result<()> {
@@ -19,7 +19,7 @@ pub fn handler(ctx: Context<BurnGsol>, amount: u64) -> Result<()> {
             &accounts.token_program,
         )?;
     } else {
-        return Err(BeamProgramError::MintWindowExceeded.into());
+        return Err(BeamError::MintWindowExceeded.into());
     }
 
     todo!("Add checks that burning is allowed");

--- a/programs/sunrise_beam/src/instructions/burn_gsol.rs
+++ b/programs/sunrise_beam/src/instructions/burn_gsol.rs
@@ -2,26 +2,37 @@ use crate::{token, utils::get_cpi_program_id, BeamError, BurnGsol};
 use anchor_lang::prelude::*;
 
 pub fn handler(ctx: Context<BurnGsol>, amount: u64) -> Result<()> {
-    let accounts = &ctx.accounts;
-    let state_account = &accounts.state;
+    let state = &mut ctx.accounts.state;
 
-    let cpi_program = get_cpi_program_id(&accounts.sysvar.to_account_info())?;
-    state_account.check_beam_validity(&accounts.beam, &cpi_program)?;
+    let cpi_program = get_cpi_program_id(&ctx.accounts.sysvar.to_account_info())?;
+    state.check_beam_validity(&ctx.accounts.beam, &cpi_program)?;
 
-    let can_burn = { true };
+    let can_burn = {
+        let allocation = state.get_mut_allocation(&ctx.accounts.beam.key());
+        if allocation.is_none() {
+            return Err(BeamError::UnidentifiedBeam.into());
+        }
+        let allocation = allocation.unwrap();
+
+        if allocation.minted > amount {
+            allocation.minted = allocation.minted.checked_sub(amount).unwrap();
+            true
+        } else {
+            false
+        }
+    };
 
     if can_burn {
         token::burn(
             amount,
-            &accounts.gsol_mint.to_account_info(),
-            &accounts.mint_gsol_to_owner.to_account_info(),
-            &accounts.mint_gsol_to.to_account_info(),
-            &accounts.token_program,
+            &ctx.accounts.gsol_mint.to_account_info(),
+            &ctx.accounts.mint_gsol_to_owner.to_account_info(),
+            &ctx.accounts.mint_gsol_to.to_account_info(),
+            &ctx.accounts.token_program,
         )?;
     } else {
-        return Err(BeamError::MintWindowExceeded.into());
+        return Err(BeamError::BurnWindowExceeded.into());
     }
 
-    todo!("Add checks that burning is allowed");
     Ok(())
 }

--- a/programs/sunrise_beam/src/instructions/export_mint_authority.rs
+++ b/programs/sunrise_beam/src/instructions/export_mint_authority.rs
@@ -1,6 +1,6 @@
 use anchor_lang::prelude::*;
 use anchor_spl::token::spl_token::instruction::AuthorityType;
-use anchor_spl::token::{set_authority, SetAuthority};
+use anchor_spl::token::{self, SetAuthority};
 
 use crate::{ExportMintAuthority, GSOL_AUTHORITY};
 
@@ -26,7 +26,7 @@ pub fn handler(ctx: Context<ExportMintAuthority>) -> Result<()> {
         signer,
     );
 
-    set_authority(
+    token::set_authority(
         cpi_ctx,
         AuthorityType::MintTokens,
         Some(ctx.accounts.new_authority.key()),

--- a/programs/sunrise_beam/src/instructions/export_mint_authority.rs
+++ b/programs/sunrise_beam/src/instructions/export_mint_authority.rs
@@ -1,7 +1,8 @@
-use crate::{seeds::GSOL_MINT_AUTHORITY, ExportMintAuthority};
 use anchor_lang::prelude::*;
 use anchor_spl::token::spl_token::instruction::AuthorityType;
 use anchor_spl::token::{set_authority, SetAuthority};
+
+use crate::{ExportMintAuthority, GSOL_AUTHORITY};
 
 pub fn handler(ctx: Context<ExportMintAuthority>) -> Result<()> {
     let state = &ctx.accounts.state;
@@ -11,7 +12,7 @@ pub fn handler(ctx: Context<ExportMintAuthority>) -> Result<()> {
 
     let seeds = &[
         state_key.as_ref(),
-        GSOL_MINT_AUTHORITY,
+        GSOL_AUTHORITY,
         &[state.gsol_mint_authority_bump],
     ];
     let signer = &[&seeds[..]];

--- a/programs/sunrise_beam/src/instructions/export_mint_authority.rs
+++ b/programs/sunrise_beam/src/instructions/export_mint_authority.rs
@@ -1,0 +1,34 @@
+use crate::{seeds::GSOL_MINT_AUTHORITY, ExportMintAuthority};
+use anchor_lang::prelude::*;
+use anchor_spl::token::spl_token::instruction::AuthorityType;
+use anchor_spl::token::{set_authority, SetAuthority};
+
+pub fn handler(ctx: Context<ExportMintAuthority>) -> Result<()> {
+    let state = &ctx.accounts.state;
+    let state_key = state.key();
+    let gsol_mint_authority = &ctx.accounts.gsol_mint_authority;
+    let gsol_mint = &ctx.accounts.gsol_mint;
+
+    let seeds = &[
+        state_key.as_ref(),
+        GSOL_MINT_AUTHORITY,
+        &[state.gsol_mint_authority_bump],
+    ];
+    let signer = &[&seeds[..]];
+
+    let cpi_ctx = CpiContext::new_with_signer(
+        ctx.accounts.token_program.to_account_info(),
+        SetAuthority {
+            current_authority: gsol_mint_authority.to_account_info(),
+            account_or_mint: gsol_mint.to_account_info(),
+        },
+        signer,
+    );
+
+    set_authority(
+        cpi_ctx,
+        AuthorityType::MintTokens,
+        Some(ctx.accounts.new_authority.key()),
+    )?;
+    Ok(())
+}

--- a/programs/sunrise_beam/src/instructions/mint_gsol.rs
+++ b/programs/sunrise_beam/src/instructions/mint_gsol.rs
@@ -1,4 +1,4 @@
-use crate::{token, utils::get_cpi_program_id, BeamProgramError, MintGsol};
+use crate::{token, utils::get_cpi_program_id, BeamError, MintGsol};
 use anchor_lang::prelude::*;
 
 pub fn handler(ctx: Context<MintGsol>, amount: u64) -> Result<()> {
@@ -20,7 +20,7 @@ pub fn handler(ctx: Context<MintGsol>, amount: u64) -> Result<()> {
             &accounts.state,
         )?;
     } else {
-        return Err(BeamProgramError::MintWindowExceeded.into());
+        return Err(BeamError::MintWindowExceeded.into());
     }
 
     todo!("Add checks that minting is allowed");

--- a/programs/sunrise_beam/src/instructions/mint_gsol.rs
+++ b/programs/sunrise_beam/src/instructions/mint_gsol.rs
@@ -1,57 +1,44 @@
+use crate::{system, token, utils, BeamError, MintGsol};
 use anchor_lang::prelude::*;
-
-use crate::system::check_beam_validity;
-use crate::utils::get_cpi_program_id;
-use crate::{token, BeamError, MintGsol};
 
 pub fn handler(ctx: Context<MintGsol>, amount: u64) -> Result<()> {
     let state = &mut ctx.accounts.state;
     let gsol_mint = &ctx.accounts.gsol_mint;
 
-    let cpi_program = get_cpi_program_id(&ctx.accounts.sysvar.to_account_info())?;
-    check_beam_validity(state, &ctx.accounts.beam, &cpi_program)?;
+    let cpi_program = utils::get_cpi_program_id(&ctx.accounts.sysvar.to_account_info())?;
+    system::check_beam_validity(state, &ctx.accounts.beam, &cpi_program)?;
 
-    let can_mint = {
-        let pre_supply = state.pre_supply;
-        let details = state.get_mut_beam_details(&ctx.accounts.beam.key());
-        if details.is_none() {
-            return Err(BeamError::UnidentifiedBeam.into());
-        }
+    let pre_supply = state.pre_supply;
+    let effective_supply = gsol_mint.supply.checked_sub(pre_supply).unwrap();
 
-        let allocation = details.unwrap();
-        let effective_supply = gsol_mint.supply.checked_sub(pre_supply).unwrap();
+    let details = state
+        .get_mut_beam_details(&ctx.accounts.beam.key())
+        .ok_or(BeamError::UnidentifiedBeam)?;
 
-        let mint_window = if effective_supply != 0 {
-            (allocation.allocation as u64)
-                .checked_mul(effective_supply)
-                .unwrap()
-                .checked_div(100)
-                .unwrap()
-        } else {
-            // Let the first request mint without restrictions. The allocations will come into effect afterwards.
-            amount
-        };
-
-        if allocation.minted < mint_window {
-            allocation.minted = allocation.minted.checked_add(amount).unwrap();
-            true
-        } else {
-            false
-        }
+    let mint_window = if effective_supply != 0 {
+        (details.allocation as u64)
+            .checked_mul(effective_supply)
+            .unwrap()
+            .checked_div(100)
+            .unwrap()
+    } else {
+        // Let the first request mint without restrictions. The allocations will come into effect afterwards.
+        amount
     };
 
-    if can_mint {
-        token::mint_to(
-            amount,
-            &ctx.accounts.gsol_mint.to_account_info(),
-            &ctx.accounts.gsol_mint_authority,
-            &ctx.accounts.mint_gsol_to.to_account_info(),
-            &ctx.accounts.token_program,
-            &ctx.accounts.state,
-        )?;
-    } else {
+    if details.minted > mint_window {
         return Err(BeamError::MintWindowExceeded.into());
     }
+
+    details.minted = details.minted.checked_add(amount).unwrap();
+    token::mint_to(
+        amount,
+        &ctx.accounts.gsol_mint.to_account_info(),
+        &ctx.accounts.gsol_mint_authority,
+        &ctx.accounts.mint_gsol_to.to_account_info(),
+        &ctx.accounts.token_program,
+        &ctx.accounts.state,
+    )?;
 
     Ok(())
 }

--- a/programs/sunrise_beam/src/instructions/mint_gsol.rs
+++ b/programs/sunrise_beam/src/instructions/mint_gsol.rs
@@ -21,11 +21,16 @@ pub fn handler(ctx: Context<MintGsol>, amount: u64) -> Result<()> {
         let allocation = details.unwrap();
         let effective_supply = gsol_mint.supply.checked_sub(pre_supply).unwrap();
 
-        let mint_window = (allocation.allocation as u64)
-            .checked_mul(effective_supply)
-            .unwrap()
-            .checked_div(100)
-            .unwrap();
+        let mint_window = if effective_supply != 0 {
+            (allocation.allocation as u64)
+                .checked_mul(effective_supply)
+                .unwrap()
+                .checked_div(100)
+                .unwrap()
+        } else {
+            // Let the first request mint without restrictions. The allocations will come into effect afterwards.
+            amount
+        };
 
         if allocation.minted < mint_window {
             allocation.minted = allocation.minted.checked_add(amount).unwrap();

--- a/programs/sunrise_beam/src/instructions/mint_gsol.rs
+++ b/programs/sunrise_beam/src/instructions/mint_gsol.rs
@@ -1,45 +1,12 @@
-use crate::{
-    seeds::GSOL_MINT_AUTHORITY, state::ControllerState, token, utils::get_cpi_program_id,
-    BeamProgramError,
-};
+use crate::{token, utils::get_cpi_program_id, BeamProgramError, MintGsol};
 use anchor_lang::prelude::*;
-use anchor_lang::solana_program::sysvar::{
-    instructions::Instructions as SysvarInstructions, SysvarId,
-};
-use anchor_spl::token::{Mint, Token, TokenAccount};
-
-#[derive(Accounts)]
-pub struct MintGsol<'info> {
-    #[account(
-        mut,
-        has_one = gsol_mint,
-    )]
-    pub state: Box<Account<'info, ControllerState>>,
-    pub beam: Signer<'info>,
-    #[account(mut)]
-    pub gsol_mint: Box<Account<'info, Mint>>,
-    #[account(
-        seeds = [state.key().as_ref(), GSOL_MINT_AUTHORITY],
-        bump = state.gsol_mint_authority_bump
-    )]
-    pub gsol_mint_authority: SystemAccount<'info>,
-    #[account(mut, token::mint = gsol_mint)]
-    pub mint_gsol_to: Box<Account<'info, TokenAccount>>,
-    pub token_program: Program<'info, Token>,
-    /// CHECK: We check that the address is that of the instructions sysvar.
-    #[account(constraint = SysvarInstructions::check_id(sysvar.key))]
-    pub sysvar: UncheckedAccount<'info>,
-}
 
 pub fn handler(ctx: Context<MintGsol>, amount: u64) -> Result<()> {
     let accounts = &ctx.accounts;
+    let state_account = &accounts.state;
 
     let cpi_program = get_cpi_program_id(&accounts.sysvar.to_account_info())?;
-    crate::check_beam_parameters(
-        &accounts.state,
-        &accounts.beam.to_account_info(),
-        &cpi_program,
-    )?;
+    state_account.check_beam_validity(&accounts.beam, &cpi_program)?;
 
     let can_mint = { true };
 

--- a/programs/sunrise_beam/src/instructions/mint_gsol.rs
+++ b/programs/sunrise_beam/src/instructions/mint_gsol.rs
@@ -2,27 +2,48 @@ use crate::{token, utils::get_cpi_program_id, BeamError, MintGsol};
 use anchor_lang::prelude::*;
 
 pub fn handler(ctx: Context<MintGsol>, amount: u64) -> Result<()> {
-    let accounts = &ctx.accounts;
-    let state_account = &accounts.state;
+    let state = &mut ctx.accounts.state;
+    let gsol_mint = &ctx.accounts.gsol_mint;
 
-    let cpi_program = get_cpi_program_id(&accounts.sysvar.to_account_info())?;
-    state_account.check_beam_validity(&accounts.beam, &cpi_program)?;
+    let cpi_program = get_cpi_program_id(&ctx.accounts.sysvar.to_account_info())?;
+    state.check_beam_validity(&ctx.accounts.beam, &cpi_program)?;
 
-    let can_mint = { true };
+    let can_mint = {
+        let pre_supply = state.pre_supply;
+        let allocation = state.get_mut_allocation(&ctx.accounts.beam.key());
+        if allocation.is_none() {
+            return Err(BeamError::UnidentifiedBeam.into());
+        }
+
+        let allocation = allocation.unwrap();
+        let effective_supply = gsol_mint.supply.checked_sub(pre_supply).unwrap();
+
+        let mint_window = (allocation.allocation as u64)
+            .checked_mul(effective_supply)
+            .unwrap()
+            .checked_div(100)
+            .unwrap();
+
+        if allocation.minted < mint_window {
+            allocation.minted = allocation.minted.checked_add(amount).unwrap();
+            true
+        } else {
+            false
+        }
+    };
 
     if can_mint {
         token::mint_to(
             amount,
-            &accounts.gsol_mint.to_account_info(),
-            &accounts.gsol_mint_authority,
-            &accounts.mint_gsol_to.to_account_info(),
-            &accounts.token_program,
-            &accounts.state,
+            &ctx.accounts.gsol_mint.to_account_info(),
+            &ctx.accounts.gsol_mint_authority,
+            &ctx.accounts.mint_gsol_to.to_account_info(),
+            &ctx.accounts.token_program,
+            &ctx.accounts.state,
         )?;
     } else {
         return Err(BeamError::MintWindowExceeded.into());
     }
 
-    todo!("Add checks that minting is allowed");
     Ok(())
 }

--- a/programs/sunrise_beam/src/instructions/mint_gsol.rs
+++ b/programs/sunrise_beam/src/instructions/mint_gsol.rs
@@ -5,6 +5,7 @@ pub fn handler(ctx: Context<MintGsol>, amount: u64) -> Result<()> {
     let state = &mut ctx.accounts.state;
     let gsol_mint = &ctx.accounts.gsol_mint;
 
+    // Check that the executing program is valid.
     let cpi_program = utils::get_cpi_program_id(&ctx.accounts.sysvar.to_account_info())?;
     system::check_beam_validity(state, &ctx.accounts.beam, &cpi_program)?;
 
@@ -22,7 +23,7 @@ pub fn handler(ctx: Context<MintGsol>, amount: u64) -> Result<()> {
             .checked_div(100)
             .unwrap()
     } else {
-        // Let the first request mint without restrictions. The allocations will come into effect afterwards.
+        // Mint initially with no restrictions. The allocations will come into effect afterwards.
         amount
     };
 

--- a/programs/sunrise_beam/src/instructions/mod.rs
+++ b/programs/sunrise_beam/src/instructions/mod.rs
@@ -1,13 +1,17 @@
 pub mod burn_gsol;
+pub mod export_mint_authority;
 pub mod mint_gsol;
 pub mod register_beam;
 pub mod register_state;
 pub mod remove_beam;
+pub mod update_allocations;
 pub mod update_state;
 
 pub use burn_gsol::*;
+pub use export_mint_authority::*;
 pub use mint_gsol::*;
 pub use register_beam::*;
 pub use register_state::*;
 pub use remove_beam::*;
+pub use update_allocations::*;
 pub use update_state::*;

--- a/programs/sunrise_beam/src/instructions/register_beam.rs
+++ b/programs/sunrise_beam/src/instructions/register_beam.rs
@@ -1,12 +1,19 @@
-use crate::{state::RegisterBeamInput, BeamProgramError, RegisterBeam};
+use crate::{state::Allocation, RegisterBeam};
 use anchor_lang::prelude::*;
 
-pub fn handler(ctx: Context<RegisterBeam>, input: RegisterBeamInput) -> Result<()> {
+pub fn handler(ctx: Context<RegisterBeam>, beam_key: Pubkey) -> Result<()> {
     let state = &mut ctx.accounts.state;
 
-    // TODO: Reallocate space here instead of erroring?.
-    if state.push_allocation(input.into())?.is_none() {
-        return Err(BeamProgramError::WouldExceedBeamCapacity.into());
+    if state
+        .push_allocation(Allocation::new(beam_key, 0))?
+        .is_none()
+    {
+        let state_info = state.to_account_info();
+        state.resize(
+            &state_info,
+            &ctx.accounts.payer,
+            &ctx.accounts.system_program,
+        )?;
     }
 
     Ok(())

--- a/programs/sunrise_beam/src/instructions/register_beam.rs
+++ b/programs/sunrise_beam/src/instructions/register_beam.rs
@@ -1,13 +1,10 @@
-use crate::{state::BeamDetails, system, RegisterBeam};
 use anchor_lang::prelude::*;
+use crate::{state::BeamDetails, system, RegisterBeam};
 
 pub fn handler(ctx: Context<RegisterBeam>, beam_key: Pubkey) -> Result<()> {
     let state = &mut ctx.accounts.state;
 
-    if state
-        .push_allocation(BeamDetails::new(beam_key, 0))?
-        .is_none()
-    {
+    if state.add_beam(BeamDetails::new(beam_key, 0))?.is_none() {
         system::resize_state(state, &ctx.accounts.payer, &ctx.accounts.system_program)?;
     }
 

--- a/programs/sunrise_beam/src/instructions/register_beam.rs
+++ b/programs/sunrise_beam/src/instructions/register_beam.rs
@@ -1,19 +1,16 @@
-use crate::{state::Allocation, RegisterBeam};
 use anchor_lang::prelude::*;
+
+use crate::system::resize_state;
+use crate::{state::BeamDetails, RegisterBeam};
 
 pub fn handler(ctx: Context<RegisterBeam>, beam_key: Pubkey) -> Result<()> {
     let state = &mut ctx.accounts.state;
 
     if state
-        .push_allocation(Allocation::new(beam_key, 0))?
+        .push_allocation(BeamDetails::new(beam_key, 0))?
         .is_none()
     {
-        let state_info = state.to_account_info();
-        state.resize(
-            &state_info,
-            &ctx.accounts.payer,
-            &ctx.accounts.system_program,
-        )?;
+        resize_state(state, &ctx.accounts.payer, &ctx.accounts.system_program)?;
     }
 
     Ok(())

--- a/programs/sunrise_beam/src/instructions/register_beam.rs
+++ b/programs/sunrise_beam/src/instructions/register_beam.rs
@@ -1,7 +1,5 @@
+use crate::{state::BeamDetails, system, RegisterBeam};
 use anchor_lang::prelude::*;
-
-use crate::system::resize_state;
-use crate::{state::BeamDetails, RegisterBeam};
 
 pub fn handler(ctx: Context<RegisterBeam>, beam_key: Pubkey) -> Result<()> {
     let state = &mut ctx.accounts.state;
@@ -10,7 +8,7 @@ pub fn handler(ctx: Context<RegisterBeam>, beam_key: Pubkey) -> Result<()> {
         .push_allocation(BeamDetails::new(beam_key, 0))?
         .is_none()
     {
-        resize_state(state, &ctx.accounts.payer, &ctx.accounts.system_program)?;
+        system::resize_state(state, &ctx.accounts.payer, &ctx.accounts.system_program)?;
     }
 
     Ok(())

--- a/programs/sunrise_beam/src/instructions/register_beam.rs
+++ b/programs/sunrise_beam/src/instructions/register_beam.rs
@@ -1,20 +1,5 @@
-use crate::state::{ControllerState, RegisterBeamInput};
-use crate::BeamProgramError;
+use crate::{state::RegisterBeamInput, BeamProgramError, RegisterBeam};
 use anchor_lang::prelude::*;
-
-#[derive(Accounts)]
-#[instruction(input: RegisterBeamInput)]
-pub struct RegisterBeam<'info> {
-    #[account(mut, has_one = update_authority)]
-    pub state: Account<'info, ControllerState>,
-    #[account(mut)] // might have to pay for a resize
-    pub payer: Signer<'info>,
-    pub update_authority: Signer<'info>,
-    /// CHECK: The beam being registered is a valid account.
-    #[account(constraint = beam_state.key() == input.beam)]
-    pub beam_state: UncheckedAccount<'info>,
-    pub system_program: Program<'info, System>,
-}
 
 pub fn handler(ctx: Context<RegisterBeam>, input: RegisterBeamInput) -> Result<()> {
     let state = &mut ctx.accounts.state;

--- a/programs/sunrise_beam/src/instructions/register_state.rs
+++ b/programs/sunrise_beam/src/instructions/register_state.rs
@@ -1,20 +1,13 @@
-use crate::{state::RegisterStateInput, token::create_mint, RegisterState};
+use crate::{state::RegisterStateInput, RegisterState};
 use anchor_lang::prelude::*;
 
 pub fn handler(ctx: Context<RegisterState>, input: RegisterStateInput) -> Result<()> {
     let state_account = &mut ctx.accounts.state;
 
     let auth_bump = *ctx.bumps.get("gsol_mint_authority").unwrap();
-    state_account.register(input, auth_bump, &ctx.accounts.gsol_mint.key());
+    let mint_key = ctx.accounts.gsol_mint.key();
+    let mint_supply = ctx.accounts.gsol_mint.supply;
 
-    create_mint(
-        &ctx.accounts.payer,
-        &ctx.accounts.gsol_mint.to_account_info(),
-        &ctx.accounts.gsol_mint_authority.key(),
-        &ctx.accounts.system_program,
-        &ctx.accounts.token_program,
-        &ctx.accounts.rent.to_account_info(),
-    )?;
-
+    state_account.register(input, auth_bump, &mint_key, mint_supply);
     Ok(())
 }

--- a/programs/sunrise_beam/src/instructions/register_state.rs
+++ b/programs/sunrise_beam/src/instructions/register_state.rs
@@ -5,7 +5,6 @@ pub fn handler(ctx: Context<RegisterState>, input: RegisterStateInput) -> Result
     let state_account = &mut ctx.accounts.state;
 
     let auth_bump = *ctx.bumps.get("gsol_mint_authority").unwrap();
-
     state_account.register(input, auth_bump, &ctx.accounts.gsol_mint.key());
 
     create_mint(

--- a/programs/sunrise_beam/src/instructions/register_state.rs
+++ b/programs/sunrise_beam/src/instructions/register_state.rs
@@ -1,28 +1,5 @@
-use crate::seeds::GSOL_MINT_AUTHORITY;
-use crate::state::{ControllerState, RegisterStateInput};
-use crate::token::create_mint;
+use crate::{state::RegisterStateInput, token::create_mint, RegisterState};
 use anchor_lang::prelude::*;
-use anchor_spl::token::Token;
-
-#[derive(Accounts)]
-#[instruction(input: RegisterStateInput)]
-pub struct RegisterState<'info> {
-    #[account(
-        init,
-        space = ControllerState::size(input.initial_capacity),
-        payer = payer
-    )]
-    pub state: Account<'info, ControllerState>,
-    #[account(mut)]
-    pub payer: Signer<'info>,
-    #[account(mut)]
-    pub gsol_mint: Signer<'info>,
-    #[account(seeds = [state.key().as_ref(), GSOL_MINT_AUTHORITY], bump)]
-    pub gsol_mint_authority: UncheckedAccount<'info>,
-    pub system_program: Program<'info, System>,
-    pub token_program: Program<'info, Token>,
-    pub rent: Sysvar<'info, Rent>,
-}
 
 pub fn handler(ctx: Context<RegisterState>, input: RegisterStateInput) -> Result<()> {
     let state_account = &mut ctx.accounts.state;

--- a/programs/sunrise_beam/src/instructions/remove_beam.rs
+++ b/programs/sunrise_beam/src/instructions/remove_beam.rs
@@ -1,5 +1,5 @@
-use crate::{BeamError, RemoveBeam};
 use anchor_lang::prelude::*;
+use crate::{BeamError, RemoveBeam};
 
 pub fn handler(ctx: Context<RemoveBeam>, beam: Pubkey) -> Result<()> {
     if ctx.accounts.state.remove_beam(&beam).is_none() {

--- a/programs/sunrise_beam/src/instructions/remove_beam.rs
+++ b/programs/sunrise_beam/src/instructions/remove_beam.rs
@@ -3,7 +3,7 @@ use anchor_lang::prelude::*;
 
 pub fn handler(ctx: Context<RemoveBeam>, beam: Pubkey) -> Result<()> {
     if ctx.accounts.state.remove_beam(&beam).is_none() {
-        return Err(BeamError::BeamNotPresent.into());
+        return Err(BeamError::UnidentifiedBeam.into());
     }
 
     Ok(())

--- a/programs/sunrise_beam/src/instructions/remove_beam.rs
+++ b/programs/sunrise_beam/src/instructions/remove_beam.rs
@@ -1,9 +1,9 @@
-use crate::{BeamProgramError, RemoveBeam};
+use crate::{BeamError, RemoveBeam};
 use anchor_lang::prelude::*;
 
 pub fn handler(ctx: Context<RemoveBeam>, beam: Pubkey) -> Result<()> {
     if ctx.accounts.state.remove_beam(&beam).is_none() {
-        return Err(BeamProgramError::BeamNotPresent.into());
+        return Err(BeamError::BeamNotPresent.into());
     }
 
     Ok(())

--- a/programs/sunrise_beam/src/instructions/remove_beam.rs
+++ b/programs/sunrise_beam/src/instructions/remove_beam.rs
@@ -1,13 +1,5 @@
-use crate::state::*;
-use crate::BeamProgramError;
+use crate::{BeamProgramError, RemoveBeam};
 use anchor_lang::prelude::*;
-
-#[derive(Accounts)]
-pub struct RemoveBeam<'info> {
-    #[account(mut, has_one = update_authority)]
-    pub state: Account<'info, ControllerState>,
-    pub update_authority: Signer<'info>,
-}
 
 pub fn handler(ctx: Context<RemoveBeam>, beam: Pubkey) -> Result<()> {
     if ctx.accounts.state.remove_beam(&beam).is_none() {

--- a/programs/sunrise_beam/src/instructions/update_allocations.rs
+++ b/programs/sunrise_beam/src/instructions/update_allocations.rs
@@ -1,0 +1,36 @@
+use crate::{state::Allocation, UpdateBeamAllocations};
+use anchor_lang::prelude::*;
+use std::collections::HashSet;
+
+pub fn handler(ctx: Context<UpdateBeamAllocations>, values: Vec<Allocation>) -> Result<()> {
+    let values: Vec<Allocation> = values
+        .into_iter()
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+    let mut final_keys: Vec<Pubkey> = values.iter().map(|value| value.beam).collect();
+
+    let state = &mut ctx.accounts.state;
+    let mut initial_keys: Vec<Pubkey> = state
+        .allocations
+        .iter()
+        .filter_map(|alloc| {
+            if alloc.beam != Pubkey::default() {
+                Some(alloc.beam)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    require_eq!(initial_keys.len(), final_keys.len());
+
+    initial_keys.sort();
+    final_keys.sort();
+    for _ in 0..final_keys.len() {
+        require_keys_eq!(final_keys[0], initial_keys[0]);
+    }
+
+    state.allocations = values;
+    Ok(())
+}

--- a/programs/sunrise_beam/src/instructions/update_allocations.rs
+++ b/programs/sunrise_beam/src/instructions/update_allocations.rs
@@ -1,36 +1,20 @@
-use crate::{state::Allocation, UpdateBeamAllocations};
+use crate::{state::AllocationUpdate, UpdateBeamAllocations};
 use anchor_lang::prelude::*;
-use std::collections::HashSet;
 
-pub fn handler(ctx: Context<UpdateBeamAllocations>, values: Vec<Allocation>) -> Result<()> {
-    let values: Vec<Allocation> = values
-        .into_iter()
-        .collect::<HashSet<_>>()
-        .into_iter()
-        .collect();
-    let mut final_keys: Vec<Pubkey> = values.iter().map(|value| value.beam).collect();
-
+pub fn handler(ctx: Context<UpdateBeamAllocations>, values: Vec<AllocationUpdate>) -> Result<()> {
     let state = &mut ctx.accounts.state;
-    let mut initial_keys: Vec<Pubkey> = state
-        .allocations
-        .iter()
-        .filter_map(|alloc| {
-            if alloc.beam != Pubkey::default() {
-                Some(alloc.beam)
-            } else {
-                None
-            }
-        })
-        .collect();
 
-    require_eq!(initial_keys.len(), final_keys.len());
-
-    initial_keys.sort();
-    final_keys.sort();
-    for _ in 0..final_keys.len() {
-        require_keys_eq!(final_keys[0], initial_keys[0]);
+    for value in values {
+        if let Some(found) = state.get_mut_allocation(&value.beam) {
+            found.allocation = value.new_allocation;
+        } else {
+            todo!("maybe error?");
+        }
     }
 
-    state.allocations = values;
+    let mut sum: u8 = 0;
+    state.allocations.iter().for_each(|a| sum += a.allocation);
+    require_eq!(sum, 100);
+
     Ok(())
 }

--- a/programs/sunrise_beam/src/instructions/update_allocations.rs
+++ b/programs/sunrise_beam/src/instructions/update_allocations.rs
@@ -1,12 +1,14 @@
-use crate::{state::AllocationUpdate, UpdateBeamAllocations};
 use anchor_lang::prelude::*;
+
+use crate::state::AllocationUpdate;
+use crate::UpdateBeamAllocations;
 
 pub fn handler(ctx: Context<UpdateBeamAllocations>, values: Vec<AllocationUpdate>) -> Result<()> {
     let state = &mut ctx.accounts.state;
 
     for value in values {
-        if let Some(found) = state.get_mut_allocation(&value.beam) {
-            found.allocation = value.new_allocation;
+        if let Some(details) = state.get_mut_beam_details(&value.beam) {
+            details.allocation = value.new_allocation;
         } else {
             todo!("maybe error?");
         }

--- a/programs/sunrise_beam/src/instructions/update_allocations.rs
+++ b/programs/sunrise_beam/src/instructions/update_allocations.rs
@@ -1,7 +1,7 @@
 use anchor_lang::prelude::*;
 
 use crate::state::AllocationUpdate;
-use crate::UpdateBeamAllocations;
+use crate::{BeamError, UpdateBeamAllocations};
 
 pub fn handler(ctx: Context<UpdateBeamAllocations>, values: Vec<AllocationUpdate>) -> Result<()> {
     let state = &mut ctx.accounts.state;
@@ -10,7 +10,7 @@ pub fn handler(ctx: Context<UpdateBeamAllocations>, values: Vec<AllocationUpdate
         if let Some(details) = state.get_mut_beam_details(&value.beam) {
             details.allocation = value.new_allocation;
         } else {
-            todo!("maybe error?");
+            return Err(BeamError::UnidentifiedBeam.into());
         }
     }
 

--- a/programs/sunrise_beam/src/instructions/update_state.rs
+++ b/programs/sunrise_beam/src/instructions/update_state.rs
@@ -1,12 +1,5 @@
-use crate::state::*;
+use crate::{state::*, UpdateState};
 use anchor_lang::prelude::*;
-
-#[derive(Accounts)]
-pub struct UpdateState<'info> {
-    #[account(mut,has_one=update_authority)]
-    pub state: Account<'info, ControllerState>,
-    pub update_authority: Signer<'info>,
-}
 
 pub fn handler(ctx: Context<UpdateState>, input: UpdateStateInput) -> Result<()> {
     ctx.accounts.state.update(input);

--- a/programs/sunrise_beam/src/instructions/update_state.rs
+++ b/programs/sunrise_beam/src/instructions/update_state.rs
@@ -1,5 +1,7 @@
-use crate::{state::*, UpdateState};
 use anchor_lang::prelude::*;
+
+use crate::state::*;
+use crate::UpdateState;
 
 pub fn handler(ctx: Context<UpdateState>, input: UpdateStateInput) -> Result<()> {
     ctx.accounts.state.update(input);

--- a/programs/sunrise_beam/src/lib.rs
+++ b/programs/sunrise_beam/src/lib.rs
@@ -44,9 +44,9 @@ pub mod sunrise_beam {
 
     pub fn update_allocations(
         ctx: Context<UpdateBeamAllocations>,
-        allocs: Vec<Allocation>,
+        values: Vec<AllocationUpdate>,
     ) -> Result<()> {
-        update_allocations::handler(ctx, allocs)
+        update_allocations::handler(ctx, values)
     }
 
     /// CPI request from a beam program to mint gsol. This checks that the beam's
@@ -84,8 +84,7 @@ pub struct RegisterState<'info> {
     pub state: Account<'info, ControllerState>,
     #[account(mut)]
     pub payer: Signer<'info>,
-    #[account(mut)]
-    pub gsol_mint: Signer<'info>,
+    pub gsol_mint: Account<'info, Mint>,
     #[account(seeds = [state.key().as_ref(), GSOL_MINT_AUTHORITY], bump)]
     pub gsol_mint_authority: UncheckedAccount<'info>,
     pub system_program: Program<'info, System>,
@@ -195,30 +194,30 @@ pub struct ExportMintAuthority<'info> {
 #[error_code]
 pub enum BeamError {
     /// Thrown if an instruction parameter could cause invalid behaviour.
-    #[msg("Invariant violated by parameter input")]
+    #[msg("Invariant violated by parameter input.")]
     InvalidParameter,
 
     /// Thrown if a beam's allocation doesn't support minting the set amount.
-    #[msg("This beam does not support minting this amount")]
+    #[msg("This beam does not support minting this amount.")]
     MintWindowExceeded,
 
     /// Thrown if a beam's allocation doesn't support burning the set amount.
-    #[msg("This beam does not support burning this amount")]
+    #[msg("This beam does not support burning this amount.")]
     BurnWindowExceeded,
 
     /// Thrown if a state has hit the maximum number of beams it can support.
-    #[msg("Can't exceed the beam capacity of this state")]
+    #[msg("Can't exceed the beam capacity of this state.")]
     WouldExceedBeamCapacity,
 
-    /// Thrown if we try to add a beam that's already present in the allocations vec.
-    #[msg("Tried to register an already-registered beam")]
+    /// Thrown on an attempt to register a beam that's already present.
+    #[msg("Tried to register an already-registered beam.")]
     DuplicateBeamEntry,
 
     /// Thrown if an action requires a beam be present, but it isn't.
-    #[msg("Expected beam to be present in allocations but it isn't")]
-    BeamNotPresent,
+    #[msg("Not a valid beam that this program recognizes.")]
+    UnidentifiedBeam,
 
     /// Thrown the program directly making the CPI isn't the beam program.
     #[msg("Cpi isn't directly being made by beam program.")]
-    UnexpectedCallingProgram,
+    UnidentifiedCallingProgram,
 }

--- a/programs/sunrise_beam/src/seeds.rs
+++ b/programs/sunrise_beam/src/seeds.rs
@@ -1,1 +1,0 @@
-pub const GSOL_MINT_AUTHORITY: &[u8] = b"gsol_mint_authority";

--- a/programs/sunrise_beam/src/state.rs
+++ b/programs/sunrise_beam/src/state.rs
@@ -56,8 +56,7 @@ impl ControllerState {
         self.yield_account = input.yield_account;
         self.gsol_mint = *gsol_mint;
         self.gsol_mint_authority_bump = gsol_mint_auth_bump;
-        self.allocations = Vec::with_capacity(input.initial_capacity);
-        self.allocations = Vec::default(); // Todo: Use Vec::with_capacity()?
+        self.allocations = vec![Allocation::default(); input.initial_capacity];
     }
 
     pub fn update(&mut self, input: UpdateStateInput) {
@@ -129,6 +128,17 @@ impl ControllerState {
         self.allocations
             .iter()
             .any(|allocation| allocation.beam == *beam)
+    }
+
+    pub fn check_beam_validity(&self, beam: &AccountInfo, cpi_program_id: &Pubkey) -> Result<()> {
+        if !self.contains_beam(beam.key) {
+            return Err(BeamProgramError::BeamNotPresent.into());
+        }
+        if beam.owner != cpi_program_id {
+            return Err(BeamProgramError::UnexpectedCallingProgram.into());
+        }
+
+        Ok(())
     }
 }
 

--- a/programs/sunrise_beam/src/system.rs
+++ b/programs/sunrise_beam/src/system.rs
@@ -5,6 +5,24 @@ use crate::{
 };
 use anchor_lang::prelude::*;
 
+/// Verifies that a mint request is valid by:
+/// - Checking that the beam is present in the state.
+/// - Checking that the executing program owns the beam.
+pub fn check_beam_validity(
+    state: &Account<'_, State>,
+    beam: &AccountInfo,
+    cpi_program_id: &Pubkey,
+) -> Result<()> {
+    if state.contains_beam(beam.key) {
+        return Err(BeamError::UnidentifiedBeam.into());
+    }
+    if beam.owner != cpi_program_id {
+        return Err(BeamError::UnidentifiedCallingProgram.into());
+    }
+
+    Ok(())
+}
+
 pub fn resize_state<'a>(
     state: &mut Account<'a, State>,
     payer: &AccountInfo<'a>,
@@ -26,21 +44,6 @@ pub fn resize_state<'a>(
     state
         .allocations
         .extend(std::iter::repeat(BeamDetails::default()));
-
-    Ok(())
-}
-
-pub fn check_beam_validity(
-    state: &Account<'_, State>,
-    beam: &AccountInfo,
-    cpi_program_id: &Pubkey,
-) -> Result<()> {
-    if state.contains_beam(beam.key) {
-        return Err(BeamError::UnidentifiedBeam.into());
-    }
-    if beam.owner != cpi_program_id {
-        return Err(BeamError::UnidentifiedCallingProgram.into());
-    }
 
     Ok(())
 }

--- a/programs/sunrise_beam/src/system.rs
+++ b/programs/sunrise_beam/src/system.rs
@@ -1,0 +1,46 @@
+use crate::{
+    state::{BeamDetails, State},
+    utils::resize_account,
+    BeamError,
+};
+use anchor_lang::prelude::*;
+
+pub fn resize_state<'a>(
+    state: &mut Account<'a, State>,
+    payer: &AccountInfo<'a>,
+    system_program: &AccountInfo<'a>,
+) -> Result<()> {
+    let window = state.alloc_window;
+    if window == 0 {
+        return Err(BeamError::WouldExceedBeamCapacity.into());
+    }
+
+    let new_length = state
+        .allocations
+        .len()
+        .checked_add(window as usize)
+        .unwrap();
+    let new_size = State::size(new_length);
+
+    resize_account(&state.to_account_info(), payer, system_program, new_size)?;
+    state
+        .allocations
+        .extend(std::iter::repeat(BeamDetails::default()));
+
+    Ok(())
+}
+
+pub fn check_beam_validity(
+    state: &Account<'_, State>,
+    beam: &AccountInfo,
+    cpi_program_id: &Pubkey,
+) -> Result<()> {
+    if state.contains_beam(beam.key) {
+        return Err(BeamError::UnidentifiedBeam.into());
+    }
+    if beam.owner != cpi_program_id {
+        return Err(BeamError::UnidentifiedCallingProgram.into());
+    }
+
+    Ok(())
+}

--- a/programs/sunrise_beam/src/token.rs
+++ b/programs/sunrise_beam/src/token.rs
@@ -2,6 +2,7 @@ use crate::{state::State, GSOL_AUTHORITY};
 use anchor_lang::prelude::*;
 use anchor_spl::token;
 
+/// Mint new tokens to a token-account with the mint-authority's signature.
 pub fn mint_to<'a>(
     amount: u64,
     mint: &AccountInfo<'a>,
@@ -28,6 +29,7 @@ pub fn mint_to<'a>(
     token::mint_to(cpi_ctx, amount)
 }
 
+/// Burn tokens from a token-account with the owner's signature.
 pub fn burn<'a>(
     amount: u64,
     mint: &AccountInfo<'a>,

--- a/programs/sunrise_beam/src/token.rs
+++ b/programs/sunrise_beam/src/token.rs
@@ -1,4 +1,4 @@
-use crate::{seeds::GSOL_MINT_AUTHORITY, state::ControllerState};
+use crate::{state::State, GSOL_AUTHORITY};
 use anchor_lang::prelude::*;
 use anchor_spl::token;
 
@@ -8,12 +8,12 @@ pub fn mint_to<'a>(
     mint_authority: &AccountInfo<'a>,
     recipient_token_account: &AccountInfo<'a>,
     token_program: &AccountInfo<'a>,
-    state: &Account<'a, ControllerState>,
+    state: &Account<'a, State>,
 ) -> Result<()> {
     let state_address = state.key();
     let seeds = &[
         state_address.as_ref(),
-        GSOL_MINT_AUTHORITY,
+        GSOL_AUTHORITY,
         &[state.gsol_mint_authority_bump],
     ];
     let pda_signer = &[&seeds[..]];

--- a/programs/sunrise_beam/src/token.rs
+++ b/programs/sunrise_beam/src/token.rs
@@ -1,45 +1,7 @@
-use crate::seeds::GSOL_MINT_AUTHORITY;
-use crate::state::ControllerState;
+use crate::{seeds::GSOL_MINT_AUTHORITY, state::ControllerState};
 use anchor_lang::prelude::*;
-use anchor_lang::solana_program::program::invoke;
-use anchor_lang::solana_program::system_instruction::create_account;
 use anchor_spl::token;
-use anchor_spl::token::{Mint, Token};
 
-pub fn create_mint<'a>(
-    payer: &AccountInfo<'a>,
-    mint: &AccountInfo<'a>,
-    mint_authority: &Pubkey,
-    system_program: &Program<'a, System>,
-    token_program: &Program<'a, Token>,
-    rent_sysvar: &AccountInfo<'a>,
-) -> Result<()> {
-    let rent = Rent::get()?;
-    let lamports = rent.minimum_balance(Mint::LEN);
-    invoke(
-        &create_account(
-            payer.key,
-            mint.key,
-            lamports,
-            Mint::LEN as u64,
-            token_program.key,
-        ),
-        &[
-            payer.clone(),
-            mint.clone(),
-            system_program.to_account_info().clone(),
-        ],
-    )?;
-
-    let accounts = token::InitializeMint {
-        mint: mint.clone(),
-        rent: rent_sysvar.clone(),
-    };
-    let cpi_ctx = CpiContext::new(token_program.to_account_info(), accounts);
-    token::initialize_mint(cpi_ctx, 9, mint_authority, Some(mint_authority))
-}
-
-#[allow(dead_code)]
 pub fn mint_to<'a>(
     amount: u64,
     mint: &AccountInfo<'a>,
@@ -66,7 +28,6 @@ pub fn mint_to<'a>(
     token::mint_to(cpi_ctx, amount)
 }
 
-#[allow(dead_code)]
 pub fn burn<'a>(
     amount: u64,
     mint: &AccountInfo<'a>,

--- a/programs/sunrise_beam/src/utils.rs
+++ b/programs/sunrise_beam/src/utils.rs
@@ -2,6 +2,7 @@ use anchor_lang::prelude::*;
 use anchor_lang::solana_program::sysvar::instructions::get_instruction_relative;
 use anchor_lang::solana_program::{program::invoke, system_instruction, sysvar::rent::Rent};
 
+/// Get the executing program using the `Instructions` sysvar.
 pub fn get_cpi_program_id(ix_sysvar: &AccountInfo) -> Result<Pubkey> {
     let relative_ix = get_instruction_relative(0, ix_sysvar)?;
     Ok(relative_ix.program_id)


### PR DESCRIPTION
* Implements registering a beam with its initial allocation set to zero.
* Adds new instruction handlers for updating beam allocations and to export the Gsol authority.
* Renames `ControllerState` to `State` and `Allocation` to `BeamDetails`.
* Introduces a `pre_supply` field on the State struct and `minted` field on the BeamDetails struct for use in tracking how much gsol each beam has minted since the dawn of the controller program.
* Adds checks that ensure that a beam can't mint if it's allocation is exceeded, or burn tokens that weren't minted through it.